### PR TITLE
Add function to get payment methods by currency

### DIFF
--- a/__mocks__/currency-data.js
+++ b/__mocks__/currency-data.js
@@ -4,14 +4,15 @@ module.exports = {
       payment_methods: [
         'le_credit',
         'paypal',
-        'stripe'
+        'stripe',
       ],
     },
     CAD: {
       payment_methods: [
         'le_credit',
         'paypal',
-        'stripe'
+        'stripe',
+        'maple_syrup_eh',
       ],
     },
   },

--- a/__mocks__/currency-data.js
+++ b/__mocks__/currency-data.js
@@ -1,0 +1,18 @@
+module.exports = {
+  currencies: {
+    AUD: {
+      payment_methods: [
+        'le_credit',
+        'paypal',
+        'stripe'
+      ],
+    },
+    CAD: {
+      payment_methods: [
+        'le_credit',
+        'paypal',
+        'stripe'
+      ],
+    },
+  },
+}

--- a/currency-data.js
+++ b/currency-data.js
@@ -1,0 +1,97 @@
+module.exports = {
+  currencies: {
+    AUD: {
+      payment_methods: [
+        'le_credit',
+        'paypal',
+        'stripe',
+      ],
+    },
+    CAD: {
+      payment_methods: [
+        'le_credit',
+        'paypal',
+        'stripe',
+      ],
+    },
+    EUR: {
+      payment_methods: [
+        'le_credit',
+        'paypal',
+        'stripe',
+      ],
+    },
+    HKD: {
+      payment_methods: [
+        'le_credit',
+        'paypal',
+        'stripe',
+      ],
+    },
+    INR: {
+      payment_methods: [
+        'le_credit',
+        'stripe',
+      ],
+    },
+    ILS: {
+      payment_methods: [
+        'le_credit',
+        'paypal',
+        'stripe',
+      ],
+    },
+    KRW: {
+      payment_methods: [
+        'le_credit',
+        'stripe',
+      ],
+    },
+    MYR: {
+      payment_methods: [
+        'le_credit',
+        'paypal',
+        'stripe',
+      ],
+    },
+    NZD: {
+      payment_methods: [
+        'le_credit',
+        'paypal',
+        'stripe',
+      ],
+    },
+    PHP: {
+      payment_methods: [
+        'le_credit',
+        'stripe',
+      ],
+    },
+    SGD: {
+      payment_methods: [
+        'le_credit',
+        'stripe',
+      ],
+    },
+    ZAR: {
+      payment_methods: [
+        'le_credit',
+        'stripe',
+      ],
+    },
+    GBP: {
+      payment_methods: [
+        'le_credit',
+        'paypal',
+        'stripe',
+      ],
+    },
+    USD: {
+      payment_methods: [
+        'le_credit',
+        'paypal',
+        'stripe',
+      ],
+    },
+  },
+}

--- a/index.js
+++ b/index.js
@@ -1,6 +1,14 @@
 var uniq = require('lodash.uniq');
 
-var regions = require('./region-data').regions
+var currencies = require('./currency-data').currencies
+
+var regions = require('./region-data').regions.map(function (region) {
+  return Object.assign({},
+    region,
+    { payment_methods: currencies[region.currency_code].payment_methods }
+  )
+})
+
 var defaultRegionCode = require('./region-data').defaultRegionCode
 
 var zeroDecimalCurrencies = [

--- a/index.js
+++ b/index.js
@@ -44,8 +44,17 @@ function getDefaultRegionName() {
   return regions.find(function(region) {return region.code === defaultRegionCode}).name
 }
 
+function getCurrencyCodes() {
+  return Object.keys(currencies)
+}
+
 function getCurrencies() {
-  return uniq(regions.map(function(region) {return region.currency_code})).sort()
+  console.warn('getCurrencies() is deprecated from lib-regions 0.1.10. Please use getCurrencyCodes() instead.')
+  return getCurrencyCodes()
+}
+
+function getPaymentMethodsByCurrencyCode(currencyCode) {
+  return currencies[currencyCode].payment_methods
 }
 
 function getZeroDecimalCurrencies() {
@@ -73,7 +82,9 @@ module.exports = {
   getDefaultRegion: getDefaultRegion,
   getDefaultRegionCode: getDefaultRegionCode,
   getDefaultRegionName: getDefaultRegionName,
+  getCurrencyCodes: getCurrencyCodes,
   getCurrencies: getCurrencies,
+  getPaymentMethodsByCurrencyCode: getPaymentMethodsByCurrencyCode,
   getZeroDecimalCurrencies: getZeroDecimalCurrencies,
   getRegionLang: getRegionLang,
   getRegionNamesAndCode: getRegionNamesAndCode

--- a/index.test.js
+++ b/index.test.js
@@ -11,12 +11,13 @@ describe('getRegions()', function() {
       {code: 'AU', name: 'Australia', lang: 'en-AU', currency_code: 'AUD', payment_methods: [
         'le_credit',
         'paypal',
-        'stripe'
+        'stripe',
       ]},
       {code: 'CA', name: 'Canada', lang: 'en-CA', currency_code: 'CAD', payment_methods: [
         'le_credit',
         'paypal',
-        'stripe'
+        'stripe',
+        'maple_syrup_eh',
       ]}
     ])
   })
@@ -44,7 +45,8 @@ describe('getRegionByCode()', function() {
       payment_methods: [
         'le_credit',
         'paypal',
-        'stripe'
+        'stripe',
+        'maple_syrup_eh',
       ],
     })
   })
@@ -74,14 +76,24 @@ describe('getDefaultRegionName()', function() {
   })
 })
 
-describe('getCurrencies()', function() {
-  it('should return an array of currencies', function() {
-    expect(regionModule.getCurrencies()).to.deep.equal(['AUD', 'CAD'])
+describe('getCurrencyCodes()', function() {
+  it('should return an array of currency codes', function() {
+    expect(regionModule.getCurrencyCodes()).to.deep.equal(['AUD', 'CAD'])
+  })
+})
+
+describe('getPaymentMethodsByCurrencyCode()', function() {
+  it('should return an array of payment methods', function() {
+    expect(regionModule.getPaymentMethodsByCurrencyCode('AUD')).to.deep.equal([
+      'le_credit',
+      'paypal',
+      'stripe',
+    ])
   })
 })
 
 describe('getZeroDecimalCurrencies()', function() {
-  it('should return an array of currencies', function() {
+  it('should return an array of currency codes', function() {
     expect(regionModule.getZeroDecimalCurrencies()).to.be.an('array');
   })
 })

--- a/index.test.js
+++ b/index.test.js
@@ -1,14 +1,23 @@
 var expect = require('chai').expect
 
 jest.mock('./region-data.js')
+jest.mock('./currency-data.js')
 
 var regionModule = require('./index')
 
 describe('getRegions()', function() {
   it('should return the region info', function() {
     expect(regionModule.getRegions()).to.deep.equal([
-      {code: 'AU', name: 'Australia', lang: 'en-AU', currency_code: 'AUD'},
-      {code: 'CA', name: 'Canada', lang: 'en-CA', currency_code: 'CAD'}
+      {code: 'AU', name: 'Australia', lang: 'en-AU', currency_code: 'AUD', payment_methods: [
+        'le_credit',
+        'paypal',
+        'stripe'
+      ]},
+      {code: 'CA', name: 'Canada', lang: 'en-CA', currency_code: 'CAD', payment_methods: [
+        'le_credit',
+        'paypal',
+        'stripe'
+      ]}
     ])
   })
 })
@@ -27,14 +36,28 @@ describe('getRegionNames()', function() {
 
 describe('getRegionByCode()', function() {
   it('should return the info for the given region code', function() {
-    expect(regionModule.getRegionByCode('CA')).to.deep.equal({code: 'CA', name: 'Canada', lang: 'en-CA', currency_code: 'CAD'})
+    expect(regionModule.getRegionByCode('CA')).to.deep.equal({
+      code: 'CA',
+      name: 'Canada',
+      lang: 'en-CA',
+      currency_code: 'CAD',
+      payment_methods: [
+        'le_credit',
+        'paypal',
+        'stripe'
+      ],
+    })
   })
 })
 
 describe('getDefaultRegion()', function() {
   it('should return the default region\'s info', function() {
     expect(regionModule.getDefaultRegion()).to.deep.equal(
-      {code: 'AU', name: 'Australia', lang: 'en-AU', currency_code: 'AUD'}
+      {code: 'AU', name: 'Australia', lang: 'en-AU', currency_code: 'AUD', payment_methods: [
+        'le_credit',
+        'paypal',
+        'stripe'
+      ]}
     )
   })
 })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lib-regions",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "Region information for Luxury Escapes",
   "main": "index.js",
   "scripts": {

--- a/region-data.js
+++ b/region-data.js
@@ -5,193 +5,108 @@ module.exports = {
       name: 'Australia',
       lang: 'en-AU',
       currency_code: 'AUD',
-      payment_methods: [
-        'le_credit',
-        'paypal',
-        'stripe'
-      ]
     },
     {
       code: 'CA',
       name: 'Canada',
       lang: 'en-CA',
       currency_code: 'CAD',
-      payment_methods: [
-        'le_credit',
-        'paypal',
-        'stripe'
-      ]
     },
     {
       code: 'FR',
       name: 'France',
       lang: 'en-FR',
       currency_code: 'EUR',
-      payment_methods: [
-        'le_credit',
-        'paypal',
-        'stripe'
-      ]
     },
     {
       code: 'DE',
       name: 'Germany',
       lang: 'en-DE',
       currency_code: 'EUR',
-      payment_methods: [
-        'le_credit',
-        'paypal',
-        'stripe'
-      ]
     },
     {
       code: 'HK',
       name: 'Hong Kong',
       lang: 'en-HK',
       currency_code: 'HKD',
-      payment_methods: [
-        'le_credit',
-        'paypal',
-        'stripe'
-      ]
     },
     {
       code: 'IN',
       name: 'India',
       lang: 'en-IN',
       currency_code: 'INR',
-      payment_methods: [
-        'le_credit',
-        'stripe'
-      ]
     },
     {
       code: 'IE',
       name: 'Ireland',
       lang: 'en-IE',
       currency_code: 'EUR',
-      payment_methods: [
-        'le_credit',
-        'paypal',
-        'stripe'
-      ]
     },
     {
       code: 'IL',
       name: 'Israel',
       lang: 'en-IL',
       currency_code: 'ILS',
-      payment_methods: [
-        'le_credit',
-        'paypal',
-        'stripe'
-      ]
     },
     {
       code: 'IT',
       name: 'Italy',
       lang: 'en-IT',
       currency_code: 'EUR',
-      payment_methods: [
-        'le_credit',
-        'paypal',
-        'stripe'
-      ]
     },
     {
       code: 'KR',
       name: 'Korea',
       lang: 'en-KR',
       currency_code: 'KRW',
-      payment_methods: [
-        'le_credit',
-        'stripe'
-      ]
     },
     {
       code: 'MY',
       name: 'Malaysia',
       lang: 'en-MY',
       currency_code: 'MYR',
-      payment_methods: [
-        'le_credit',
-        'paypal',
-        'stripe'
-      ]
     },
     {
       code: 'NZ',
       name: 'New Zealand',
       lang: 'en-NZ',
       currency_code: 'NZD',
-      payment_methods: [
-        'le_credit',
-        'paypal',
-        'stripe'
-      ]
     },
     {
       code: 'PH',
       name: 'Philippines',
       lang: 'en-PH',
       currency_code: 'PHP',
-      payment_methods: [
-        'le_credit',
-        'stripe'
-      ]
     },
     {
       code: 'SG',
       name: 'Singapore',
       lang: 'en-SG',
       currency_code: 'SGD',
-      payment_methods: [
-        'le_credit',
-        'stripe'
-      ]
     },
     {
       code: 'ZA',
       name: 'South Africa',
       lang: 'en-ZA',
       currency_code: 'ZAR',
-      payment_methods: [
-        'le_credit',
-        'stripe'
-      ]
     },
     {
       code: 'ES',
       name: 'Spain',
       lang: 'en-ES',
       currency_code: 'EUR',
-      payment_methods: [
-        'le_credit',
-        'paypal',
-        'stripe'
-      ]
     },
     {
       code: 'GB',
       name: 'United Kingdom',
       lang: 'en-GB',
       currency_code: 'GBP',
-      payment_methods: [
-        'le_credit',
-        'paypal',
-        'stripe'
-      ]
     },
     {
       code: 'US',
       name: 'United States',
       lang: 'en-US',
       currency_code: 'USD',
-      payment_methods: [
-        'le_credit',
-        'paypal',
-        'stripe'
-      ]
     },
   ],
 


### PR DESCRIPTION
As a side effect, payment methods for currencies now live in a separate list so we don't have to repeat the payment methods for regions that use the same currency.