### PR TITLE
Remove references to PayPal payment method, replaced by Braintree

### DIFF
--- a/__mocks__/currency-data.js
+++ b/__mocks__/currency-data.js
@@ -3,14 +3,14 @@ module.exports = {
     AUD: {
       payment_methods: [
         'le_credit',
-        'paypal',
+        'braintree',
         'stripe',
       ],
     },
     CAD: {
       payment_methods: [
         'le_credit',
-        'paypal',
+        'braintree',
         'stripe',
         'maple_syrup_eh',
       ],

--- a/currency-data.js
+++ b/currency-data.js
@@ -3,7 +3,6 @@ module.exports = {
     AUD: {
       payment_methods: [
         'le_credit',
-        'paypal',
         'stripe',
         'braintree',
       ],
@@ -11,21 +10,18 @@ module.exports = {
     CAD: {
       payment_methods: [
         'le_credit',
-        'paypal',
         'stripe',
       ],
     },
     EUR: {
       payment_methods: [
         'le_credit',
-        'paypal',
         'stripe',
       ],
     },
     HKD: {
       payment_methods: [
         'le_credit',
-        'paypal',
         'stripe',
       ],
     },
@@ -38,7 +34,6 @@ module.exports = {
     ILS: {
       payment_methods: [
         'le_credit',
-        'paypal',
         'stripe',
       ],
     },
@@ -51,14 +46,12 @@ module.exports = {
     MYR: {
       payment_methods: [
         'le_credit',
-        'paypal',
         'stripe',
       ],
     },
     NZD: {
       payment_methods: [
         'le_credit',
-        'paypal',
         'stripe',
         'braintree',
       ],
@@ -84,14 +77,12 @@ module.exports = {
     GBP: {
       payment_methods: [
         'le_credit',
-        'paypal',
         'stripe',
       ],
     },
     USD: {
       payment_methods: [
         'le_credit',
-        'paypal',
         'stripe',
       ],
     },

--- a/index.test.js
+++ b/index.test.js
@@ -16,7 +16,7 @@ describe('getRegions()', function() {
         currency_code: 'AUD',
         payment_methods: [
           'le_credit',
-          'paypal',
+          'braintree',
           'stripe',
         ],
       },
@@ -28,7 +28,7 @@ describe('getRegions()', function() {
         currency_code: 'CAD',
         payment_methods: [
           'le_credit',
-          'paypal',
+          'braintree',
           'stripe',
           'maple_syrup_eh',
         ],
@@ -59,7 +59,7 @@ describe('getRegionByCode()', function() {
       currency_code: 'CAD',
       payment_methods: [
         'le_credit',
-        'paypal',
+        'braintree',
         'stripe',
         'maple_syrup_eh',
       ],
@@ -77,7 +77,7 @@ describe('getDefaultRegion()', function() {
       currency_code: 'AUD',
       payment_methods: [
         'le_credit',
-        'paypal',
+        'braintree',
         'stripe'
       ],
     })
@@ -106,7 +106,7 @@ describe('getPaymentMethodsByCurrencyCode()', function() {
   it('should return an array of payment methods', function() {
     expect(regionModule.getPaymentMethodsByCurrencyCode('AUD')).to.deep.equal([
       'le_credit',
-      'paypal',
+      'braintree',
       'stripe',
     ])
   })


### PR DESCRIPTION
Since we're now exclusively using Braintree for PayPal, I figure we shouldn't have obsolete references to PayPal hanging around confusing everyone.