### PR TITLE
Sometimes null or undefined is passed in

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,6 +29,9 @@ function getRegionNames() {
 }
 
 function getRegionByCode(regionCode) {
+  if (!regionCode) {
+    return null
+  }
   return regions.find(function(region) {return region.code.toLowerCase() === regionCode.toLowerCase()})
 }
 


### PR DESCRIPTION
Blows up when calling `toLowerCase()` on null or undefined