### PR TITLE
feat: add brand awareness

### DIFF
--- a/__mocks__/currency-data.js
+++ b/__mocks__/currency-data.js
@@ -1,20 +1,30 @@
 module.exports = {
   currencies: {
-    AUD: {
-      payment_methods: [
-        'le_credit',
-        'braintree',
-        'stripe',
-        'qantas'
-      ],
+    scoopontravel: {
+      AUD: {
+        payment_methods: [
+          'braintree',
+          'stripe'
+        ]
+      }
     },
-    CAD: {
-      payment_methods: [
-        'le_credit',
-        'braintree',
-        'stripe',
-        'maple_syrup_eh',
-      ],
+    luxuryescapes: {
+      AUD: {
+        payment_methods: [
+          'le_credit',
+          'braintree',
+          'stripe',
+          'qantas'
+        ],
+      },
+      CAD: {
+        payment_methods: [
+          'le_credit',
+          'braintree',
+          'stripe',
+          'maple_syrup_eh',
+        ],
+      },
     },
   },
 }

--- a/__mocks__/region-data.js
+++ b/__mocks__/region-data.js
@@ -1,48 +1,60 @@
 const DEFAULT_MAILING_ADDRESS = 'Level 1, 50-56 York St, South Melbourne, VIC 3205, AUSTRALIA'
 
 module.exports = {
-  regions: [
-    {
-      code: 'AU',
-      name: 'Australia',
-      lang: 'en-AU',
-      phone_prefix: '61',
-      currency_formatting_locale: 'en-AU',
-      currency_code: 'AUD',
-      flag_id: 'au_iuox02',
-      phone: {
-        local: {
-          human_readable: '1300 88 99 00',
-          number: '1300889900',
+  regions: {
+    luxuryescapes: [
+      {
+        code: 'AU',
+        name: 'Australia',
+        lang: 'en-AU',
+        phone_prefix: '61',
+        currency_formatting_locale: 'en-AU',
+        currency_code: 'AUD',
+        flag_id: 'au_iuox02',
+        phone: {
+          local: {
+            human_readable: '1300 88 99 00',
+            number: '1300889900',
+          },
+          international: {
+            human_readable: '+61 2 8320 6845',
+            number: '+61283206845',
+          },
         },
-        international: {
-          human_readable: '+61 2 8320 6845',
-          number: '+61283206845',
-        },
+        mailing_address: DEFAULT_MAILING_ADDRESS,
       },
-      mailing_address: DEFAULT_MAILING_ADDRESS,
-    },
-    {
-      code: 'CA',
-      name: 'Canada',
-      lang: 'en-CA',
-      phone_prefix: '1',
-      currency_formatting_locale: 'en-CA',
-      currency_code: 'CAD',
-      flag_id: 'ca_nacvxi',
-      phone: {
-        local: {
-          human_readable: '778 300 0814',
-          number: '7783000814',
+      {
+        code: 'CA',
+        name: 'Canada',
+        lang: 'en-CA',
+        phone_prefix: '1',
+        currency_formatting_locale: 'en-CA',
+        currency_code: 'CAD',
+        flag_id: 'ca_nacvxi',
+        phone: {
+          local: {
+            human_readable: '778 300 0814',
+            number: '7783000814',
+          },
+          international: {
+            human_readable: '+61 2 8320 6845',
+            number: '+61283206845',
+          },
         },
-        international: {
-          human_readable: '+61 2 8320 6845',
-          number: '+61283206845',
-        },
-      },
-      mailing_address: DEFAULT_MAILING_ADDRESS,
-    },
-  ],
+        mailing_address: DEFAULT_MAILING_ADDRESS,
+      }
+    ],
+    scoopontravel: [
+      {
+        code: 'AU',
+        name: 'Australia',
+        lang: 'en-AU',
+        phone_prefix: '61',
+        currency_formatting_locale: 'en-AU',
+        currency_code: 'AUD'
+      }
+    ]
+  },
 
   defaultRegionCode: 'AU',
 }

--- a/currency-data.js
+++ b/currency-data.js
@@ -1,127 +1,137 @@
 module.exports = {
   currencies: {
-    AUD: {
-      payment_methods: [
-        'le_credit',
-        'stripe',
-        'braintree',
-        'qantas'
-      ],
+    scoopontravel: {
+      AUD: {
+        payment_methods: [
+          'stripe',
+          'braintree'
+        ]
+      }
     },
-    CAD: {
-      payment_methods: [
-        'le_credit',
-        'stripe',
-      ],
-    },
-    CNY: {
-      payment_methods: [
-        'le_credit',
-        'stripe',
-      ],
-    },
-    EUR: {
-      payment_methods: [
-        'le_credit',
-        'stripe',
-      ],
-    },
-    HKD: {
-      payment_methods: [
-        'le_credit',
-        'stripe',
-      ],
-    },
-    INR: {
-      payment_methods: [
-        'le_credit',
-        'stripe',
-      ],
-    },
-    IDR: {
-      payment_methods: [
-        'le_credit',
-        'stripe',
-      ],
-    },
-    ILS: {
-      payment_methods: [
-        'le_credit',
-        'stripe',
-      ],
-    },
-    JPY: {
-      payment_methods: [
-        'le_credit',
-        'stripe',
-      ],
-    },
-    KRW: {
-      payment_methods: [
-        'le_credit',
-        'stripe',
-      ],
-    },
-    MYR: {
-      payment_methods: [
-        'le_credit',
-        'stripe',
-      ],
-    },
-    NZD: {
-      payment_methods: [
-        'le_credit',
-        'stripe',
-        'braintree',
-      ],
-    },
-    PHP: {
-      payment_methods: [
-        'le_credit',
-        'stripe',
-      ],
-    },
-    SGD: {
-      payment_methods: [
-        'le_credit',
-        'stripe',
-      ],
-    },
-    TWD: {
-      payment_methods: [
-        'le_credit',
-        'stripe',
-      ]
-    },
-    THB: {
-      payment_methods: [
-        'le_credit',
-        'stripe',
-      ]
-    },
-    ZAR: {
-      payment_methods: [
-        'le_credit',
-        'stripe',
-      ],
-    },
-    GBP: {
-      payment_methods: [
-        'le_credit',
-        'stripe',
-      ],
-    },
-    USD: {
-      payment_methods: [
-        'le_credit',
-        'stripe',
-      ],
-    },
-    VND: {
-      payment_methods: [
-        'le_credit',
-        'stripe',
-      ],
+    luxuryescapes: {
+      AUD: {
+        payment_methods: [
+          'le_credit',
+          'stripe',
+          'braintree',
+          'qantas'
+        ],
+      },
+      CAD: {
+        payment_methods: [
+          'le_credit',
+          'stripe',
+        ],
+      },
+      CNY: {
+        payment_methods: [
+          'le_credit',
+          'stripe',
+        ],
+      },
+      EUR: {
+        payment_methods: [
+          'le_credit',
+          'stripe',
+        ],
+      },
+      HKD: {
+        payment_methods: [
+          'le_credit',
+          'stripe',
+        ],
+      },
+      INR: {
+        payment_methods: [
+          'le_credit',
+          'stripe',
+        ],
+      },
+      IDR: {
+        payment_methods: [
+          'le_credit',
+          'stripe',
+        ],
+      },
+      ILS: {
+        payment_methods: [
+          'le_credit',
+          'stripe',
+        ],
+      },
+      JPY: {
+        payment_methods: [
+          'le_credit',
+          'stripe',
+        ],
+      },
+      KRW: {
+        payment_methods: [
+          'le_credit',
+          'stripe',
+        ],
+      },
+      MYR: {
+        payment_methods: [
+          'le_credit',
+          'stripe',
+        ],
+      },
+      NZD: {
+        payment_methods: [
+          'le_credit',
+          'stripe',
+          'braintree',
+        ],
+      },
+      PHP: {
+        payment_methods: [
+          'le_credit',
+          'stripe',
+        ],
+      },
+      SGD: {
+        payment_methods: [
+          'le_credit',
+          'stripe',
+        ],
+      },
+      TWD: {
+        payment_methods: [
+          'le_credit',
+          'stripe',
+        ]
+      },
+      THB: {
+        payment_methods: [
+          'le_credit',
+          'stripe',
+        ]
+      },
+      ZAR: {
+        payment_methods: [
+          'le_credit',
+          'stripe',
+        ],
+      },
+      GBP: {
+        payment_methods: [
+          'le_credit',
+          'stripe',
+        ],
+      },
+      USD: {
+        payment_methods: [
+          'le_credit',
+          'stripe',
+        ],
+      },
+      VND: {
+        payment_methods: [
+          'le_credit',
+          'stripe',
+        ],
+      },
     },
   },
 }

--- a/index.js
+++ b/index.js
@@ -1,13 +1,23 @@
-var uniq = require('lodash.uniq')
+var currencyData = require('./currency-data').currencies
+var regionData = require('./region-data').regions
 
-var currencies = require('./currency-data').currencies
+var brandRegions = Object.keys(regionData).reduce(function(acc ,k) {
+  acc[k] = regionData[k].map(function(region) {
+    return Object.assign({},
+      region,
+      { payment_methods: currencies(k)[region.currency_code].payment_methods }
+    )
+  })
+  return acc
+}, {})
 
-var regions = require('./region-data').regions.map(function (region) {
-  return Object.assign({},
-    region,
-    { payment_methods: currencies[region.currency_code].payment_methods },
-  )
-})
+function regions(brand) {
+  return brandRegions[brand || 'luxuryescapes']
+}
+
+function currencies(brand) {
+  return currencyData[brand || 'luxuryescapes']
+}
 
 var defaultRegionCode = require('./region-data').defaultRegionCode
 
@@ -16,31 +26,31 @@ var zeroDecimalCurrencies = [
   'PYG', 'RWF', 'VND', 'VUV', 'XAF', 'XOF', 'XPF'
 ]
 
-function getRegions() {
-  return regions
+function getRegions(brand) {
+  return regions(brand)
 }
 
-function getRegionCodes() {
-  return regions.map(function(region) {return region.code})
+function getRegionCodes(brand) {
+  return regions(brand).map(function(region) {return region.code})
 }
 
-function getRegionNames() {
-  return regions.map(function(region) {return region.name})
+function getRegionNames(brand) {
+  return regions(brand).map(function(region) {return region.name})
 }
 
-function getRegionByCode(regionCode) {
+function getRegionByCode(regionCode, brand) {
   if (!regionCode) {
     return null
   }
-  return regions.find(function(region) {return region.code.toLowerCase() === regionCode.toLowerCase()})
+  return regions(brand).find(function(region) {return region.code.toLowerCase() === regionCode.toLowerCase()})
 }
 
-function getDefaultRegion() {
-  return getRegionByCode(defaultRegionCode)
+function getDefaultRegion(brand) {
+  return getRegionByCode(defaultRegionCode, brand)
 }
 
-function getRegionNameByCode(code) {
-  const region = getRegionByCode(code)
+function getRegionNameByCode(code, brand) {
+  const region = getRegionByCode(code, brand)
   return region && region.name || null
 }
 
@@ -48,32 +58,32 @@ function getDefaultRegionCode() {
   return defaultRegionCode
 }
 
-function getDefaultRegionName() {
-  return regions.find(function(region) {return region.code === defaultRegionCode}).name
+function getDefaultRegionName(brand) {
+  return regions(brand).find(function(region) {return region.code === defaultRegionCode}).name
 }
 
-function getCurrencyCodes() {
-  return Object.keys(currencies)
+function getCurrencyCodes(brand) {
+  return Object.keys(currencies(brand))
 }
 
-function getPaymentMethodsByCurrencyCode(currencyCode) {
-  return currencies[currencyCode].payment_methods
+function getPaymentMethodsByCurrencyCode(currencyCode, brand) {
+  return currencies(brand)[currencyCode].payment_methods
 }
 
 function getZeroDecimalCurrencies() {
   return zeroDecimalCurrencies
 }
 
-function getRegionLang() {
-  return regions.map(function(region) {return region.lang})
+function getRegionLang(brand) {
+  return regions(brand).map(function(region) {return region.lang})
 }
 
-function getRegionPhonePrefix() {
-  return regions.map(function(region) {return region.phone_prefix})
+function getRegionPhonePrefix(brand) {
+  return regions(brand).map(function(region) {return region.phone_prefix})
 }
 
-function getRegionNamesAndCode() {
-  return regions.map(function(region) {
+function getRegionNamesAndCode(brand) {
+  return regions(brand).map(function(region) {
     return {
       name: region.name,
       code: region.code

--- a/index.test.js
+++ b/index.test.js
@@ -6,7 +6,24 @@ jest.mock('./currency-data.js')
 var regionModule = require('./index')
 
 describe('getRegions()', function() {
-  it('should return the region info', function() {
+  it('should return the region', function() {
+    expect(regionModule.getRegions('scoopontravel')).to.deep.equal([
+      {
+        code: 'AU',
+        name: 'Australia',
+        lang: 'en-AU',
+        phone_prefix: '61',
+        currency_formatting_locale: 'en-AU',
+        currency_code: 'AUD',
+        payment_methods: [
+          'braintree',
+          'stripe',
+        ],
+      },
+    ])
+  })
+
+  it('should return the region info default brand to luxuryescapes', function() {
     expect(regionModule.getRegions()).to.deep.equal([
       {
         code: 'AU',
@@ -56,17 +73,44 @@ describe('getRegions()', function() {
 
 describe('getRegionCodes()', function() {
   it('should return an array of region codes', function() {
+    expect(regionModule.getRegionCodes('scoopontravel')).to.deep.equal(['AU'])
+  })
+
+  it('should return an array of region codes default brand to luxuryescapes', function() {
     expect(regionModule.getRegionCodes()).to.deep.equal(['AU', 'CA'])
   })
 })
 
 describe('getRegionNames()', function() {
   it('should return an array of region names', function() {
+    expect(regionModule.getRegionNames('scoopontravel')).to.deep.equal(['Australia'])
+  })
+
+  it('should return an array of region names default brand to luxuryescapes', function() {
     expect(regionModule.getRegionNames()).to.deep.equal(['Australia', 'Canada'])
   })
 })
 
 describe('getRegionByCode()', function() {
+  it('should return the info for the given region code', function() {
+    expect(regionModule.getRegionByCode('AU', 'scoopontravel')).to.deep.equal({
+      code: 'AU',
+      name: 'Australia',
+      lang: 'en-AU',
+      phone_prefix: '61',
+      currency_formatting_locale: 'en-AU',
+      currency_code: 'AUD',
+      payment_methods: [
+        'braintree',
+        'stripe',
+      ],
+    })
+  })
+
+  it('should return null in brand without region', function() {
+    expect(regionModule.getRegionByCode('CA', 'scoopontravel')).to.be.undefined
+  })
+
   it('should return the info for the given region code', function() {
     expect(regionModule.getRegionByCode('CA')).to.deep.equal({
       code: 'CA',
@@ -96,16 +140,35 @@ describe('getRegionNameByCode()', function () {
   const {getRegionNameByCode} = regionModule
 
   it('returns region name if region exists', function () {
-    expect(getRegionNameByCode('AU')).to.equal('Australia')
+    expect(getRegionNameByCode('AU', 'scoopontravel')).to.equal('Australia')
   })
 
-  it('returns \'null\' code if region is absent', function () {
-    expect(getRegionNameByCode('XYZ')).to.equal(null)
+  it('returns \'null\' code if region is absent for brand', function () {
+    expect(getRegionNameByCode('CA', 'scoopontravel')).to.equal(null)
+  })
+
+  it('returns region name if region exists default brand to luxuryescapes', function () {
+    expect(getRegionNameByCode('AU')).to.equal('Australia')
   })
 })
 
 describe('getDefaultRegion()', function() {
   it('should return the default region\'s info', function() {
+    expect(regionModule.getDefaultRegion('scoopontravel')).to.deep.equal({
+      code: 'AU',
+      name: 'Australia',
+      lang: 'en-AU',
+      phone_prefix: '61',
+      currency_formatting_locale: 'en-AU',
+      currency_code: 'AUD',
+      payment_methods: [
+        'braintree',
+        'stripe'
+      ],
+    })
+  })
+
+  it('should return the default region\'s info default brand to luxuryescapes', function() {
     expect(regionModule.getDefaultRegion()).to.deep.equal({
       code: 'AU',
       name: 'Australia',
@@ -132,24 +195,43 @@ describe('getDefaultRegion()', function() {
 
 describe('getDefaultRegionCode()', function() {
   it('should return the default region\'s code', function() {
+    expect(regionModule.getDefaultRegionCode('luxuryescapes')).to.equal('AU')
+  })
+
+  it('should return the default region\'s code default brand to luxuryescapes', function() {
     expect(regionModule.getDefaultRegionCode()).to.equal('AU')
   })
 })
 
 describe('getDefaultRegionName()', function() {
   it('should return the default region\'s name', function() {
+    expect(regionModule.getDefaultRegionName('scoopontravel')).to.equal('Australia')
+  })
+
+  it('should return the default region\'s name default brand to luxuryescapes', function() {
     expect(regionModule.getDefaultRegionName()).to.equal('Australia')
   })
 })
 
 describe('getCurrencyCodes()', function() {
   it('should return an array of currency codes', function() {
+    expect(regionModule.getCurrencyCodes('scoopontravel')).to.deep.equal(['AUD'])
+  })
+
+  it('should return an array of currency codes default brand to luxuryescapes', function() {
     expect(regionModule.getCurrencyCodes()).to.deep.equal(['AUD', 'CAD'])
   })
 })
 
 describe('getPaymentMethodsByCurrencyCode()', function() {
   it('should return an array of payment methods', function() {
+    expect(regionModule.getPaymentMethodsByCurrencyCode('AUD', 'scoopontravel')).to.deep.equal([
+      'braintree',
+      'stripe',
+    ])
+  })
+
+  it('should return an array of payment methods default brand to luxuryescapes', function() {
     expect(regionModule.getPaymentMethodsByCurrencyCode('AUD')).to.deep.equal([
       'le_credit',
       'braintree',
@@ -167,12 +249,22 @@ describe('getZeroDecimalCurrencies()', function() {
 
 describe('getRegionLang()', function() {
   it('should return an array of region langs', function() {
+    expect(regionModule.getRegionLang('scoopontravel')).to.deep.equal(['en-AU'])
+  })
+
+  it('should return an array of region langs default brand to luxuryescapes', function() {
     expect(regionModule.getRegionLang()).to.deep.equal(['en-AU', 'en-CA'])
   })
 })
 
 describe('getRegionNamesAndCode()', function() {
   it('should return an array of region names and code', function() {
+    expect(regionModule.getRegionNamesAndCode('scoopontravel')).to.deep.equal([
+      {name: 'Australia', code: 'AU'},
+    ])
+  })
+
+  it('should return an array of region names and code default brand to luxuryescapes', function() {
     expect(regionModule.getRegionNamesAndCode()).to.deep.equal([
       {name: 'Australia', code: 'AU'},
       {name: 'Canada', code: 'CA'}

--- a/package.json
+++ b/package.json
@@ -13,7 +13,5 @@
     "chai": "^4.0.0",
     "jest": "^20.0.4"
   },
-  "dependencies": {
-    "lodash.uniq": "^4.5.0"
-  }
+  "dependencies": {}
 }

--- a/region-data.js
+++ b/region-data.js
@@ -1,488 +1,500 @@
 const DEFAULT_MAILING_ADDRESS = 'Level 1, 50-56 York St, South Melbourne, VIC 3205, AUSTRALIA'
 
 module.exports = {
-  regions: [
-    {
-      code: 'AU',
-      name: 'Australia',
-      lang: 'en-AU',
-      phone_prefix: '61',
-      currency_formatting_locale: 'en-AU',
-      currency_code: 'AUD',
-      flag_id: 'au_iuox02',
-      phone: {
-        local: {
-          human_readable: '1300 88 99 00',
-          number: '1300889900',
+  regions: {
+    luxuryescapes: [
+      {
+        code: 'AU',
+        name: 'Australia',
+        lang: 'en-AU',
+        phone_prefix: '61',
+        currency_formatting_locale: 'en-AU',
+        currency_code: 'AUD',
+        flag_id: 'au_iuox02',
+        phone: {
+          local: {
+            human_readable: '1300 88 99 00',
+            number: '1300889900',
+          },
+          international: {
+            human_readable: '+61 2 8320 6845',
+            number: '+61283206845',
+          },
         },
-        international: {
-          human_readable: '+61 2 8320 6845',
-          number: '+61283206845',
-        },
+        mailing_address: DEFAULT_MAILING_ADDRESS,
       },
-      mailing_address: DEFAULT_MAILING_ADDRESS,
-    },
-    {
-      code: 'CA',
-      name: 'Canada',
-      lang: 'en-CA',
-      phone_prefix: '1',
-      currency_formatting_locale: 'en-CA',
-      currency_code: 'CAD',
-      flag_id: 'ca_nacvxi',
-      phone: {
-        local: {
-          human_readable: '778 300 0814',
-          number: '7783000814',
+      {
+        code: 'CA',
+        name: 'Canada',
+        lang: 'en-CA',
+        phone_prefix: '1',
+        currency_formatting_locale: 'en-CA',
+        currency_code: 'CAD',
+        flag_id: 'ca_nacvxi',
+        phone: {
+          local: {
+            human_readable: '778 300 0814',
+            number: '7783000814',
+          },
+          international: {
+            human_readable: '+61 2 8320 6845',
+            number: '+61283206845',
+          },
         },
-        international: {
-          human_readable: '+61 2 8320 6845',
-          number: '+61283206845',
-        },
+        mailing_address: DEFAULT_MAILING_ADDRESS,
       },
-      mailing_address: DEFAULT_MAILING_ADDRESS,
-    },
-    {
-      code: 'CN',
-      name: 'China',
-      lang: 'en-CN',
-      phone_prefix: '86',
-      currency_formatting_locale: 'zh-CN',
-      currency_code: 'CNY',
-      flag_id: 'cn_nnripn',
-      phone: {
-        local: {
-          human_readable: '800 597 138',
-          number: '800597138',
+      {
+        code: 'CN',
+        name: 'China',
+        lang: 'en-CN',
+        phone_prefix: '86',
+        currency_formatting_locale: 'zh-CN',
+        currency_code: 'CNY',
+        flag_id: 'cn_nnripn',
+        phone: {
+          local: {
+            human_readable: '800 597 138',
+            number: '800597138',
+          },
+          international: {
+            human_readable: '+61 2 8320 6845',
+            number: '+61283206845',
+          },
         },
-        international: {
-          human_readable: '+61 2 8320 6845',
-          number: '+61283206845',
-        },
+        mailing_address: DEFAULT_MAILING_ADDRESS,
       },
-      mailing_address: DEFAULT_MAILING_ADDRESS,
-    },
-    {
-      code: 'FR',
-      name: 'France',
-      lang: 'en-FR',
-      phone_prefix: '33',
-      currency_formatting_locale: 'fr-FR',
-      currency_code: 'EUR',
-      flag_id: 'fr_ch1vgi',
-      phone: {
-        local: {
-          human_readable: '0805 08 42 02',
-          number: '0805084202',
+      {
+        code: 'FR',
+        name: 'France',
+        lang: 'en-FR',
+        phone_prefix: '33',
+        currency_formatting_locale: 'fr-FR',
+        currency_code: 'EUR',
+        flag_id: 'fr_ch1vgi',
+        phone: {
+          local: {
+            human_readable: '0805 08 42 02',
+            number: '0805084202',
+          },
+          international: {
+            human_readable: '+61 2 8320 6845',
+            number: '+61283206845',
+          },
         },
-        international: {
-          human_readable: '+61 2 8320 6845',
-          number: '+61283206845',
-        },
+        mailing_address: DEFAULT_MAILING_ADDRESS,
       },
-      mailing_address: DEFAULT_MAILING_ADDRESS,
-    },
-    {
-      code: 'DE',
-      name: 'Germany',
-      lang: 'en-DE',
-      phone_prefix: '49',
-      currency_formatting_locale: 'de-DE',
-      currency_code: 'EUR',
-      flag_id: 'de_wj4y6k',
-      phone: {
-        local: {
-          human_readable: '0211 38789806',
-          number: '021138789806',
+      {
+        code: 'DE',
+        name: 'Germany',
+        lang: 'en-DE',
+        phone_prefix: '49',
+        currency_formatting_locale: 'de-DE',
+        currency_code: 'EUR',
+        flag_id: 'de_wj4y6k',
+        phone: {
+          local: {
+            human_readable: '0211 38789806',
+            number: '021138789806',
+          },
+          international: {
+            human_readable: '+61 2 8320 6845',
+            number: '+61283206845',
+          },
         },
-        international: {
-          human_readable: '+61 2 8320 6845',
-          number: '+61283206845',
-        },
+        mailing_address: DEFAULT_MAILING_ADDRESS,
       },
-      mailing_address: DEFAULT_MAILING_ADDRESS,
-    },
-    {
-      code: 'HK',
-      name: 'Hong Kong',
-      lang: 'en-HK',
-      phone_prefix: '852',
-      currency_formatting_locale: 'en-HK',
-      currency_code: 'HKD',
-      flag_id: 'hk_wjyavc',
-      phone: {
-        local: {
-          human_readable: '5806 0444',
-          number: '58060444',
+      {
+        code: 'HK',
+        name: 'Hong Kong',
+        lang: 'en-HK',
+        phone_prefix: '852',
+        currency_formatting_locale: 'en-HK',
+        currency_code: 'HKD',
+        flag_id: 'hk_wjyavc',
+        phone: {
+          local: {
+            human_readable: '5806 0444',
+            number: '58060444',
+          },
+          international: {
+            human_readable: '+61 2 8320 6845',
+            number: '+61283206845',
+          },
         },
-        international: {
-          human_readable: '+61 2 8320 6845',
-          number: '+61283206845',
-        },
+        mailing_address: DEFAULT_MAILING_ADDRESS,
       },
-      mailing_address: DEFAULT_MAILING_ADDRESS,
-    },
-    {
-      code: 'IN',
-      name: 'India',
-      lang: 'en-IN',
-      phone_prefix: '91',
-      currency_formatting_locale: 'en-IN',
-      currency_code: 'INR',
-      flag_id: 'in_opf3wm',
-      phone: {
-        local: {
-          human_readable: '1800 1200 336',
-          number: '18001200336',
+      {
+        code: 'IN',
+        name: 'India',
+        lang: 'en-IN',
+        phone_prefix: '91',
+        currency_formatting_locale: 'en-IN',
+        currency_code: 'INR',
+        flag_id: 'in_opf3wm',
+        phone: {
+          local: {
+            human_readable: '1800 1200 336',
+            number: '18001200336',
+          },
+          international: {
+            human_readable: '+61 2 8320 6845',
+            number: '+61283206845',
+          },
         },
-        international: {
-          human_readable: '+61 2 8320 6845',
-          number: '+61283206845',
-        },
+        mailing_address: '6 Shenton Way, OUE Downtown 2, #33-00 Singapore 068809',
       },
-      mailing_address: '6 Shenton Way, OUE Downtown 2, #33-00 Singapore 068809',
-    },
-    {
-      code: 'ID',
-      name: 'Indonesia',
-      lang: 'en-ID',
-      phone_prefix: '62',
-      currency_formatting_locale: 'id-ID',
-      currency_code: 'IDR',
-      flag_id: 'id_yveumv',
-      phone: {
-        local: {
-          human_readable: '007 803 321 8413',
-          number: '0078033218413',
+      {
+        code: 'ID',
+        name: 'Indonesia',
+        lang: 'en-ID',
+        phone_prefix: '62',
+        currency_formatting_locale: 'id-ID',
+        currency_code: 'IDR',
+        flag_id: 'id_yveumv',
+        phone: {
+          local: {
+            human_readable: '007 803 321 8413',
+            number: '0078033218413',
+          },
+          international: {
+            human_readable: '+61 2 8320 6845',
+            number: '+61283206845',
+          },
         },
-        international: {
-          human_readable: '+61 2 8320 6845',
-          number: '+61283206845',
-        },
+        mailing_address: DEFAULT_MAILING_ADDRESS,
       },
-      mailing_address: DEFAULT_MAILING_ADDRESS,
-    },
-    {
-      code: 'IE',
-      name: 'Ireland',
-      lang: 'en-IE',
-      phone_prefix: '353',
-      currency_formatting_locale: 'en-IE',
-      currency_code: 'EUR',
-      flag_id: 'ie_kqc7pg',
-      phone: {
-        local: {
-          human_readable: '1300 88 99 00',
-          number: '1300889900',
+      {
+        code: 'IE',
+        name: 'Ireland',
+        lang: 'en-IE',
+        phone_prefix: '353',
+        currency_formatting_locale: 'en-IE',
+        currency_code: 'EUR',
+        flag_id: 'ie_kqc7pg',
+        phone: {
+          local: {
+            human_readable: '1300 88 99 00',
+            number: '1300889900',
+          },
+          international: {
+            human_readable: '+61 2 8320 6845',
+            number: '+61283206845',
+          },
         },
-        international: {
-          human_readable: '+61 2 8320 6845',
-          number: '+61283206845',
-        },
+        mailing_address: DEFAULT_MAILING_ADDRESS,
       },
-      mailing_address: DEFAULT_MAILING_ADDRESS,
-    },
-    {
-      code: 'IL',
-      name: 'Israel',
-      lang: 'en-IL',
-      phone_prefix: '972',
-      currency_formatting_locale: 'iw-IL',
-      currency_code: 'ILS',
-      flag_id: 'il_x5duyz',
-      phone: {
-        local: {
-          human_readable: '1 801 227 262',
-          number: '1801227262',
+      {
+        code: 'IL',
+        name: 'Israel',
+        lang: 'en-IL',
+        phone_prefix: '972',
+        currency_formatting_locale: 'iw-IL',
+        currency_code: 'ILS',
+        flag_id: 'il_x5duyz',
+        phone: {
+          local: {
+            human_readable: '1 801 227 262',
+            number: '1801227262',
+          },
+          international: {
+            human_readable: '+61 2 8320 6845',
+            number: '+61283206845',
+          },
         },
-        international: {
-          human_readable: '+61 2 8320 6845',
-          number: '+61283206845',
-        },
+        mailing_address: DEFAULT_MAILING_ADDRESS,
       },
-      mailing_address: DEFAULT_MAILING_ADDRESS,
-    },
-    {
-      code: 'IT',
-      name: 'Italy',
-      lang: 'en-IT',
-      phone_prefix: '39',
-      currency_formatting_locale: 'it-IT',
-      currency_code: 'EUR',
-      flag_id: 'it_yex5ap',
-      phone: {
-        local: {
-          human_readable: '1300 88 99 00',
-          number: '1300889900',
+      {
+        code: 'IT',
+        name: 'Italy',
+        lang: 'en-IT',
+        phone_prefix: '39',
+        currency_formatting_locale: 'it-IT',
+        currency_code: 'EUR',
+        flag_id: 'it_yex5ap',
+        phone: {
+          local: {
+            human_readable: '1300 88 99 00',
+            number: '1300889900',
+          },
+          international: {
+            human_readable: '+61 2 8320 6845',
+            number: '+61283206845',
+          },
         },
-        international: {
-          human_readable: '+61 2 8320 6845',
-          number: '+61283206845',
-        },
+        mailing_address: DEFAULT_MAILING_ADDRESS,
       },
-      mailing_address: DEFAULT_MAILING_ADDRESS,
-    },
-    {
-      code: 'JP',
-      name: 'Japan',
-      lang: 'en-JP',
-      phone_prefix: '81',
-      currency_formatting_locale: 'ja-JP',
-      currency_code: 'JPY',
-      flag_id: 'jp_m6elxg',
-      phone: {
-        local: {
-          human_readable: '+61 2 8320 6845',
-          number: '+61283206845',
+      {
+        code: 'JP',
+        name: 'Japan',
+        lang: 'en-JP',
+        phone_prefix: '81',
+        currency_formatting_locale: 'ja-JP',
+        currency_code: 'JPY',
+        flag_id: 'jp_m6elxg',
+        phone: {
+          local: {
+            human_readable: '+61 2 8320 6845',
+            number: '+61283206845',
+          },
+          international: {
+            human_readable: '+61 2 8320 6845',
+            number: '+61283206845',
+          },
         },
-        international: {
-          human_readable: '+61 2 8320 6845',
-          number: '+61283206845',
-        },
+        mailing_address: DEFAULT_MAILING_ADDRESS,
       },
-      mailing_address: DEFAULT_MAILING_ADDRESS,
-    },
-    {
-      code: 'KR',
-      name: 'Korea',
-      lang: 'en-KR',
-      phone_prefix: '82',
-      currency_formatting_locale: 'ko-KR',
-      currency_code: 'KRW',
-      flag_id: 'kr_mrnua8',
-      phone: {
-        local: {
-          human_readable: '0808 220 277',
-          number: '0808220277',
+      {
+        code: 'KR',
+        name: 'Korea',
+        lang: 'en-KR',
+        phone_prefix: '82',
+        currency_formatting_locale: 'ko-KR',
+        currency_code: 'KRW',
+        flag_id: 'kr_mrnua8',
+        phone: {
+          local: {
+            human_readable: '0808 220 277',
+            number: '0808220277',
+          },
+          international: {
+            human_readable: '+61 2 8320 6845',
+            number: '+61283206845',
+          },
         },
-        international: {
-          human_readable: '+61 2 8320 6845',
-          number: '+61283206845',
-        },
+        mailing_address: DEFAULT_MAILING_ADDRESS,
       },
-      mailing_address: DEFAULT_MAILING_ADDRESS,
-    },
-    {
-      code: 'MY',
-      name: 'Malaysia',
-      lang: 'en-MY',
-      phone_prefix: '60',
-      currency_formatting_locale: 'ms-MY',
-      currency_code: 'MYR',
-      flag_id: 'my_zzejgo',
-      phone: {
-        local: {
-          human_readable: '03 9212 7293',
-          number: '0392127293',
+      {
+        code: 'MY',
+        name: 'Malaysia',
+        lang: 'en-MY',
+        phone_prefix: '60',
+        currency_formatting_locale: 'ms-MY',
+        currency_code: 'MYR',
+        flag_id: 'my_zzejgo',
+        phone: {
+          local: {
+            human_readable: '03 9212 7293',
+            number: '0392127293',
+          },
+          international: {
+            human_readable: '+61 2 8320 6845',
+            number: '+61283206845',
+          },
         },
-        international: {
-          human_readable: '+61 2 8320 6845',
-          number: '+61283206845',
-        },
+        mailing_address: DEFAULT_MAILING_ADDRESS,
       },
-      mailing_address: DEFAULT_MAILING_ADDRESS,
-    },
-    {
-      code: 'NZ',
-      name: 'New Zealand',
-      lang: 'en-NZ',
-      phone_prefix: '64',
-      currency_formatting_locale: 'en-NZ',
-      currency_code: 'NZD',
-      flag_id: 'nz_o98shy',
-      phone: {
-        local: {
-          human_readable: '0800 441 457',
-          number: '0800441457',
+      {
+        code: 'NZ',
+        name: 'New Zealand',
+        lang: 'en-NZ',
+        phone_prefix: '64',
+        currency_formatting_locale: 'en-NZ',
+        currency_code: 'NZD',
+        flag_id: 'nz_o98shy',
+        phone: {
+          local: {
+            human_readable: '0800 441 457',
+            number: '0800441457',
+          },
+          international: {
+            human_readable: '+61 2 8320 6845',
+            number: '+61283206845',
+          },
         },
-        international: {
-          human_readable: '+61 2 8320 6845',
-          number: '+61283206845',
-        },
+        mailing_address: DEFAULT_MAILING_ADDRESS,
       },
-      mailing_address: DEFAULT_MAILING_ADDRESS,
-    },
-    {
-      code: 'PH',
-      name: 'Philippines',
-      lang: 'en-PH',
-      phone_prefix: '63',
-      currency_formatting_locale: 'en-PH',
-      currency_code: 'PHP',
-      flag_id: 'ph_cmq6es',
-      phone: {
-        local: {
-          human_readable: '1800 1320 0074',
-          number: '180013200074',
+      {
+        code: 'PH',
+        name: 'Philippines',
+        lang: 'en-PH',
+        phone_prefix: '63',
+        currency_formatting_locale: 'en-PH',
+        currency_code: 'PHP',
+        flag_id: 'ph_cmq6es',
+        phone: {
+          local: {
+            human_readable: '1800 1320 0074',
+            number: '180013200074',
+          },
+          international: {
+            human_readable: '+61 2 8320 6845',
+            number: '+61283206845',
+          },
         },
-        international: {
-          human_readable: '+61 2 8320 6845',
-          number: '+61283206845',
-        },
+        mailing_address: DEFAULT_MAILING_ADDRESS,
       },
-      mailing_address: DEFAULT_MAILING_ADDRESS,
-    },
-    {
-      code: 'SG',
-      name: 'Singapore',
-      lang: 'en-SG',
-      phone_prefix: '65',
-      currency_formatting_locale: 'en-SG',
-      currency_code: 'SGD',
-      flag_id: 'sg_qrenqc',
-      phone: {
-        local: {
-          human_readable: '800 492 2237',
-          number: '8004922237',
+      {
+        code: 'SG',
+        name: 'Singapore',
+        lang: 'en-SG',
+        phone_prefix: '65',
+        currency_formatting_locale: 'en-SG',
+        currency_code: 'SGD',
+        flag_id: 'sg_qrenqc',
+        phone: {
+          local: {
+            human_readable: '800 492 2237',
+            number: '8004922237',
+          },
+          international: {
+            human_readable: '+61 2 8320 6845',
+            number: '+61283206845',
+          },
         },
-        international: {
-          human_readable: '+61 2 8320 6845',
-          number: '+61283206845',
-        },
+        mailing_address: DEFAULT_MAILING_ADDRESS,
       },
-      mailing_address: DEFAULT_MAILING_ADDRESS,
-    },
-    {
-      code: 'ZA',
-      name: 'South Africa',
-      lang: 'en-ZA',
-      phone_prefix: '27',
-      currency_formatting_locale: 'af-ZA',
-      currency_code: 'ZAR',
-      flag_id: 'za_rhuusv',
-      phone: {
-        local: {
-          human_readable: '0800 060 109',
-          number: '0800060109',
+      {
+        code: 'ZA',
+        name: 'South Africa',
+        lang: 'en-ZA',
+        phone_prefix: '27',
+        currency_formatting_locale: 'af-ZA',
+        currency_code: 'ZAR',
+        flag_id: 'za_rhuusv',
+        phone: {
+          local: {
+            human_readable: '0800 060 109',
+            number: '0800060109',
+          },
+          international: {
+            human_readable: '+61 2 8320 6845',
+            number: '+61283206845',
+          },
         },
-        international: {
-          human_readable: '+61 2 8320 6845',
-          number: '+61283206845',
-        },
+        mailing_address: DEFAULT_MAILING_ADDRESS,
       },
-      mailing_address: DEFAULT_MAILING_ADDRESS,
-    },
-    {
-      code: 'ES',
-      name: 'Spain',
-      lang: 'en-ES',
-      phone_prefix: '34',
-      currency_formatting_locale: 'es-ES',
-      currency_code: 'EUR',
-      flag_id: 'es_wxszqg',
-      phone: {
-        local: {
-          human_readable: '1300 88 99 00',
-          number: '1300889900',
+      {
+        code: 'ES',
+        name: 'Spain',
+        lang: 'en-ES',
+        phone_prefix: '34',
+        currency_formatting_locale: 'es-ES',
+        currency_code: 'EUR',
+        flag_id: 'es_wxszqg',
+        phone: {
+          local: {
+            human_readable: '1300 88 99 00',
+            number: '1300889900',
+          },
+          international: {
+            human_readable: '+61 2 8320 6845',
+            number: '+61283206845',
+          },
         },
-        international: {
-          human_readable: '+61 2 8320 6845',
-          number: '+61283206845',
-        },
+        mailing_address: DEFAULT_MAILING_ADDRESS,
       },
-      mailing_address: DEFAULT_MAILING_ADDRESS,
-    },
-    {
-      code: 'TW',
-      name: 'Taiwan',
-      lang: 'en-TW',
-      phone_prefix: '886',
-      currency_formatting_locale: 'zh-TW',
-      currency_code: 'TWD',
-      flag_id: 'tw_a9lqx6',
-      phone: {
-        local: {
-          human_readable: '+61 2 8320 6845',
-          number: '+61283206845',
+      {
+        code: 'TW',
+        name: 'Taiwan',
+        lang: 'en-TW',
+        phone_prefix: '886',
+        currency_formatting_locale: 'zh-TW',
+        currency_code: 'TWD',
+        flag_id: 'tw_a9lqx6',
+        phone: {
+          local: {
+            human_readable: '+61 2 8320 6845',
+            number: '+61283206845',
+          },
+          international: {
+            human_readable: '+61 2 8320 6845',
+            number: '+61283206845',
+          },
         },
-        international: {
-          human_readable: '+61 2 8320 6845',
-          number: '+61283206845',
-        },
+        mailing_address: DEFAULT_MAILING_ADDRESS,
       },
-      mailing_address: DEFAULT_MAILING_ADDRESS,
-    },
-    {
-      code: 'TH',
-      name: 'Thailand',
-      lang: 'en-TH',
-      phone_prefix: '66',
-      currency_formatting_locale: 'th-TH',
-      currency_code: 'THB',
-      flag_id: 'th_isrxzq',
-      phone: {
-        local: {
-          human_readable: '02 026 0685',
-          number: '020260685',
+      {
+        code: 'TH',
+        name: 'Thailand',
+        lang: 'en-TH',
+        phone_prefix: '66',
+        currency_formatting_locale: 'th-TH',
+        currency_code: 'THB',
+        flag_id: 'th_isrxzq',
+        phone: {
+          local: {
+            human_readable: '02 026 0685',
+            number: '020260685',
+          },
+          international: {
+            human_readable: '+61 2 8320 6845',
+            number: '+61283206845',
+          },
         },
-        international: {
-          human_readable: '+61 2 8320 6845',
-          number: '+61283206845',
-        },
+        mailing_address: DEFAULT_MAILING_ADDRESS,
       },
-      mailing_address: DEFAULT_MAILING_ADDRESS,
-    },
-    {
-      code: 'GB',
-      name: 'United Kingdom',
-      lang: 'en-GB',
-      phone_prefix: '44',
-      currency_formatting_locale: 'en-GB',
-      currency_code: 'GBP',
-      flag_id: 'gb_ta8bez',
-      phone: {
-        local: {
-          human_readable: '020 8068 2668',
-          number: '02080682668',
+      {
+        code: 'GB',
+        name: 'United Kingdom',
+        lang: 'en-GB',
+        phone_prefix: '44',
+        currency_formatting_locale: 'en-GB',
+        currency_code: 'GBP',
+        flag_id: 'gb_ta8bez',
+        phone: {
+          local: {
+            human_readable: '020 8068 2668',
+            number: '02080682668',
+          },
+          international: {
+            human_readable: '+61 2 8320 6845',
+            number: '+61283206845',
+          },
         },
-        international: {
-          human_readable: '+61 2 8320 6845',
-          number: '+61283206845',
-        },
+        mailing_address: DEFAULT_MAILING_ADDRESS,
       },
-      mailing_address: DEFAULT_MAILING_ADDRESS,
-    },
-    {
-      code: 'US',
-      name: 'United States',
-      lang: 'en-US',
-      phone_prefix: '1',
-      currency_formatting_locale: 'en-US',
-      currency_code: 'USD',
-      flag_id: 'us_fapjn8',
-      phone: {
-        local: {
-          human_readable: '888 402 1238',
-          number: '8884021238',
+      {
+        code: 'US',
+        name: 'United States',
+        lang: 'en-US',
+        phone_prefix: '1',
+        currency_formatting_locale: 'en-US',
+        currency_code: 'USD',
+        flag_id: 'us_fapjn8',
+        phone: {
+          local: {
+            human_readable: '888 402 1238',
+            number: '8884021238',
+          },
+          international: {
+            human_readable: '+61 2 8320 6845',
+            number: '+61283206845',
+          },
         },
-        international: {
-          human_readable: '+61 2 8320 6845',
-          number: '+61283206845',
-        },
+        mailing_address: DEFAULT_MAILING_ADDRESS,
       },
-      mailing_address: DEFAULT_MAILING_ADDRESS,
-    },
-    {
-      code: 'VN',
-      name: 'Vietnam',
-      lang: 'en-VN',
-      phone_prefix: '84',
-      currency_formatting_locale: 'vi-VN',
-      currency_code: 'VND',
-      flag_id: 'vn_mixye2',
-      phone: {
-        local: {
-          human_readable: '+61 2 8320 6845',
-          number: '+61283206845',
+      {
+        code: 'VN',
+        name: 'Vietnam',
+        lang: 'en-VN',
+        phone_prefix: '84',
+        currency_formatting_locale: 'vi-VN',
+        currency_code: 'VND',
+        flag_id: 'vn_mixye2',
+        phone: {
+          local: {
+            human_readable: '+61 2 8320 6845',
+            number: '+61283206845',
+          },
+          international: {
+            human_readable: '+61 2 8320 6845',
+            number: '+61283206845',
+          },
         },
-        international: {
-          human_readable: '+61 2 8320 6845',
-          number: '+61283206845',
-        },
+        mailing_address: DEFAULT_MAILING_ADDRESS,
       },
-      mailing_address: DEFAULT_MAILING_ADDRESS,
-    },
-  ],
+    ],
+    scoopontravel: [
+      {
+        code: 'AU',
+        name: 'Australia',
+        lang: 'en-AU',
+        phone_prefix: '61',
+        currency_formatting_locale: 'en-AU',
+        currency_code: 'AUD',
+      }
+    ],
+  },
 
   defaultRegionCode: 'AU',
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1290,10 +1290,6 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
-lodash.uniq@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
-
 lodash@^4.14.0, lodash@^4.2.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"


### PR DESCRIPTION
Look up regions and currencies by brand
Default brand to luxuryescapes

Might also be useful to split out the metadata? No point in repeating...
```
        code: 'AU',
        name: 'Australia',
        lang: 'en-AU',
        currency_formatting_locale: 'en-AU',
        currency_code: 'AUD',
```
Nothing else is repeated though