### PR TITLE
[LBO-1095] Add latitude info to mobile config

### DIFF
--- a/__mocks__/region-data.js
+++ b/__mocks__/region-data.js
@@ -21,6 +21,7 @@ module.exports = {
         },
       },
       mailing_address: DEFAULT_MAILING_ADDRESS,
+      latitude_threshold: 999
     },
     {
       code: 'CA',

--- a/index.test.js
+++ b/index.test.js
@@ -45,6 +45,7 @@ describe('getRegions()', function() {
           },
         },
         mailing_address: 'Level 1, 50-56 York St, South Melbourne, VIC 3205, AUSTRALIA',
+        latitude_threshold: 999,
         payment_methods: [ 'le_credit', 'braintree', 'stripe', 'qantas' ]
       },
       {
@@ -187,6 +188,7 @@ describe('getDefaultRegion()', function() {
         },
       },
       mailing_address: 'Level 1, 50-56 York St, South Melbourne, VIC 3205, AUSTRALIA',
+      latitude_threshold: 999,
       payment_methods: [ 'le_credit', 'braintree', 'stripe', 'qantas' ]
     })
   })
@@ -295,4 +297,3 @@ describe('eachRegionStatusFromPostcode', function() {
     expect(postcodes.marketingRegionFromPostcode('5542', 'NZ')).to.eql('wellington')
   })
 })
-

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lib-regions",
-  "version": "3.1.12",
+  "version": "3.1.13",
   "description": "Region information for Luxury Escapes",
   "main": "index.js",
   "scripts": {

--- a/region-data.js
+++ b/region-data.js
@@ -23,6 +23,7 @@ module.exports = {
         default: 'international',
       },
       mailing_address: DEFAULT_MAILING_ADDRESS,
+      latitude_threshold: 999
     },
     {
       code: 'CA',


### PR DESCRIPTION
Adding latitude threshold info here, next step will be to update svc-discovery to use the latest version of the lib-regions so mobile can receive latitude payment details.