### PR TITLE
Ee 1206 enabling braintree for treatme

### DIFF
--- a/currency-data.js
+++ b/currency-data.js
@@ -43,6 +43,7 @@ module.exports = {
       NZD: {
         payment_methods: [
           'stripe',
+          'braintree',
         ]
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lib-regions",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Region information for Luxury Escapes",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Added support for paypal/braintree for NZ Treat Me. Also incremented version number to `3.2.1`.

This has no impact on LE.