### PR TITLE
camel case migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,15 @@ Region information for Luxury Escapes
 yarn test
 ```
 
+## Camel Case
+
+You can make everything camel case by:
+
+```js
+var libRegions = require('@luxuryescapes/lib-regions')
+libRegions.setCamel()
+```
+
 ## Release
 
 ```

--- a/README.md
+++ b/README.md
@@ -8,22 +8,10 @@ Region information for Luxury Escapes
 yarn test
 ```
 
-## Marketing Regions From Postcodes
-
-used for mapping postcodes to the email marketing regions that we use within AU and NZ, AU is the default country
-
-```
-const postcodes = require('lib-regions/postcodes');
-postcodes.marketingRegionFromPostcode('3000')  # returns marketing region in AU
-postcodes.marketingRegionFromPostcode('5542', 'NZ')  # specify country code for NZ
-```
-
 ## Release
 
-Use `npm` to patch, minor or whatever version:
-
 ```
-npm version patch -m "release version %s"
+yarn publish
 git push && git push --tags
 ```
 

--- a/camel.test.js
+++ b/camel.test.js
@@ -1,0 +1,31 @@
+var expect = require('chai').expect
+
+jest.mock('./region-data.js')
+jest.mock('./currency-data.js')
+
+var regionModule = require('./index')
+regionModule.setCamel()
+
+const postcodes = require('lib-regions/postcodes')
+
+describe('getRegions()', function() {
+  it('should return the region', function() {
+    expect(regionModule.getRegions('scoopontravel')).to.deep.equal([
+      {
+        code: 'AU',
+        name: 'Australia',
+        lang: 'en-AU',
+        phonePrefix: '61',
+        currencyFormattingLocale: 'en-AU',
+        currencyCode: 'AUD',
+        paymentMethods: [
+          'braintree',
+          'stripe',
+        ],
+        parnerships: [],
+        referralAmount: '50',
+        offerUrgencyTag: null
+      },
+    ])
+  })
+})

--- a/index.js
+++ b/index.js
@@ -1,8 +1,24 @@
+var camelcaseKeys = require('camelcase-keys');
 var currencyData = require('./currency-data').currencies
 var parnershipData = require('./parnership-data')
 var regionData = require('./region-data')
 var flights = require('./lib/flights')
 var countries = require('./lib/countries')
+
+var camel = false
+
+function setCamel() {
+  camel = true
+}
+
+function present(fn) {
+  return function() {
+    if (camel) {
+      return camelcaseKeys(fn.apply(null, arguments), {deep: true});
+    }
+    return fn.apply(null, arguments)
+  }
+}
 
 var brandRegions = Object.keys(regionData).reduce(function(acc ,k) {
   acc[k] = regionData[k].map(function(region) {
@@ -93,7 +109,7 @@ function getParnershipsByCurrencyCode(currencyCode, brand) {
       parnerships.push(parnershipData[paymentMethod])
     }
   })
-  
+
   return parnerships
 }
 
@@ -135,29 +151,30 @@ function getCountries() {
 }
 
 module.exports = {
-  getRegions: getRegions,
-  getRegionCodes: getRegionCodes,
-  getRegionNames: getRegionNames,
-  getRegionByCode: getRegionByCode,
-  getRegionNameByCode: getRegionNameByCode,
-  getDefaultRegion: getDefaultRegion,
-  getDefaultRegionCode: getDefaultRegionCode,
-  getDefaultRegionName: getDefaultRegionName,
-  getCurrencyCodes: getCurrencyCodes,
-  getPaymentMethodsByCurrencyCode: getPaymentMethodsByCurrencyCode,
-  getZeroDecimalCurrencies: getZeroDecimalCurrencies,
-  getRegionLang: getRegionLang,
-  getRegionReferralAmountByCode: getRegionReferralAmountByCode,
-  getRegionNamesAndCode: getRegionNamesAndCode,
-  getParnershipsByCurrencyCode: getParnershipsByCurrencyCode,
+  setCamel: setCamel,
+  getRegions: present(getRegions),
+  getRegionCodes: present(getRegionCodes),
+  getRegionNames: present(getRegionNames),
+  getRegionByCode: present(getRegionByCode),
+  getRegionNameByCode: present(getRegionNameByCode),
+  getDefaultRegion: present(getDefaultRegion),
+  getDefaultRegionCode: present(getDefaultRegionCode),
+  getDefaultRegionName: present(getDefaultRegionName),
+  getCurrencyCodes: present(getCurrencyCodes),
+  getPaymentMethodsByCurrencyCode: present(getPaymentMethodsByCurrencyCode),
+  getZeroDecimalCurrencies: present(getZeroDecimalCurrencies),
+  getRegionLang: present(getRegionLang),
+  getRegionReferralAmountByCode: present(getRegionReferralAmountByCode),
+  getRegionNamesAndCode: present(getRegionNamesAndCode),
+  getParnershipsByCurrencyCode: present(getParnershipsByCurrencyCode),
   isRegionAllowed: isRegionAllowed,
-  getRegionPhonePrefix: getRegionPhonePrefix,
-  getFlightMainPort: flights.getFlightMainPort,
-  getFlightRegions: flights.getFlightRegions,
-  getRegionDeparturePorts: flights.getRegionDeparturePorts,
-  getPopularRegionDeparturePorts: flights.getPopularRegionDeparturePorts,
-  getRegionDestinationPorts: flights.getRegionDestinationPorts,
-  getAirportByCode: flights.getAirportByCode,
-  getCountries: getCountries,
-  getParnerships: getParnerships
+  getRegionPhonePrefix: present(getRegionPhonePrefix),
+  getFlightMainPort: present(flights.getFlightMainPort),
+  getFlightRegions: present(flights.getFlightRegions),
+  getRegionDeparturePorts: present(flights.getRegionDeparturePorts),
+  getPopularRegionDeparturePorts: present(flights.getPopularRegionDeparturePorts),
+  getRegionDestinationPorts: present(flights.getRegionDestinationPorts),
+  getAirportByCode: present(flights.getAirportByCode),
+  getCountries: present(getCountries),
+  getParnerships: present(getParnerships)
 }

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ function setCamel() {
   camel = true
 }
 
-function present(fn) {
+function camelFn(fn) {
   return function() {
     if (camel) {
       return camelcaseKeys(fn.apply(null, arguments), {deep: true});
@@ -152,29 +152,29 @@ function getCountries() {
 
 module.exports = {
   setCamel: setCamel,
-  getRegions: present(getRegions),
-  getRegionCodes: present(getRegionCodes),
-  getRegionNames: present(getRegionNames),
-  getRegionByCode: present(getRegionByCode),
-  getRegionNameByCode: present(getRegionNameByCode),
-  getDefaultRegion: present(getDefaultRegion),
-  getDefaultRegionCode: present(getDefaultRegionCode),
-  getDefaultRegionName: present(getDefaultRegionName),
-  getCurrencyCodes: present(getCurrencyCodes),
-  getPaymentMethodsByCurrencyCode: present(getPaymentMethodsByCurrencyCode),
-  getZeroDecimalCurrencies: present(getZeroDecimalCurrencies),
-  getRegionLang: present(getRegionLang),
-  getRegionReferralAmountByCode: present(getRegionReferralAmountByCode),
-  getRegionNamesAndCode: present(getRegionNamesAndCode),
-  getParnershipsByCurrencyCode: present(getParnershipsByCurrencyCode),
+  getRegions: camelFn(getRegions),
+  getRegionCodes: camelFn(getRegionCodes),
+  getRegionNames: camelFn(getRegionNames),
+  getRegionByCode: camelFn(getRegionByCode),
+  getRegionNameByCode: camelFn(getRegionNameByCode),
+  getDefaultRegion: camelFn(getDefaultRegion),
+  getDefaultRegionCode: camelFn(getDefaultRegionCode),
+  getDefaultRegionName: camelFn(getDefaultRegionName),
+  getCurrencyCodes: camelFn(getCurrencyCodes),
+  getPaymentMethodsByCurrencyCode: camelFn(getPaymentMethodsByCurrencyCode),
+  getZeroDecimalCurrencies: camelFn(getZeroDecimalCurrencies),
+  getRegionLang: camelFn(getRegionLang),
+  getRegionReferralAmountByCode: camelFn(getRegionReferralAmountByCode),
+  getRegionNamesAndCode: camelFn(getRegionNamesAndCode),
+  getParnershipsByCurrencyCode: camelFn(getParnershipsByCurrencyCode),
   isRegionAllowed: isRegionAllowed,
-  getRegionPhonePrefix: present(getRegionPhonePrefix),
-  getFlightMainPort: present(flights.getFlightMainPort),
-  getFlightRegions: present(flights.getFlightRegions),
-  getRegionDeparturePorts: present(flights.getRegionDeparturePorts),
-  getPopularRegionDeparturePorts: present(flights.getPopularRegionDeparturePorts),
-  getRegionDestinationPorts: present(flights.getRegionDestinationPorts),
-  getAirportByCode: present(flights.getAirportByCode),
-  getCountries: present(getCountries),
-  getParnerships: present(getParnerships)
+  getRegionPhonePrefix: camelFn(getRegionPhonePrefix),
+  getFlightMainPort: camelFn(flights.getFlightMainPort),
+  getFlightRegions: camelFn(flights.getFlightRegions),
+  getRegionDeparturePorts: camelFn(flights.getRegionDeparturePorts),
+  getPopularRegionDeparturePorts: camelFn(flights.getPopularRegionDeparturePorts),
+  getRegionDestinationPorts: camelFn(flights.getRegionDestinationPorts),
+  getAirportByCode: camelFn(flights.getAirportByCode),
+  getCountries: camelFn(getCountries),
+  getParnerships: camelFn(getParnerships)
 }

--- a/index.test.js
+++ b/index.test.js
@@ -4,6 +4,7 @@ jest.mock('./region-data.js')
 jest.mock('./currency-data.js')
 
 var regionModule = require('./index')
+
 const postcodes = require('lib-regions/postcodes')
 
 describe('getRegions()', function() {
@@ -331,7 +332,7 @@ describe('getPaymentMethodsByCurrencyCode()', function() {
       'qantas'
     ])
   })
-  
+
   it('should return an array of payment methods default brand to luxuryescapes SGD', function() {
     expect(regionModule.getPaymentMethodsByCurrencyCode('SGD')).to.deep.equal([
       'le_credit',
@@ -415,7 +416,7 @@ describe('getParnershipsByCurrencyCode()', function() {
         accountFields: ['qff', 'qff_last_name'],
       }
     ])
-  }) 
+  })
   it('should return krisFlyer', function() {
     expect(regionModule.getParnershipsByCurrencyCode('SGD', 'luxuryescapes')).to.deep.equal([
       {
@@ -437,7 +438,7 @@ describe('getParnershipsByCurrencyCode()', function() {
         accountFields: ['kfp', 'kfp_first_name', 'kfp_last_name'],
       }
     ])
-  }) 
+  })
 });
 
 describe('eachRegionStatusFromPostcode', function() {

--- a/package.json
+++ b/package.json
@@ -16,5 +16,7 @@
     "eslint-plugin-es5": "^1.3.1",
     "jest": "^20.0.4"
   },
-  "dependencies": {}
+  "dependencies": {
+    "camelcase-keys": "^6.0.0"
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -437,10 +437,24 @@ callsites@^2.0.0:
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-2.0.0.tgz#06eb84f00eea413da86affefacbffb36093b3c50"
   integrity sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=
 
+camelcase-keys@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/camelcase-keys/-/camelcase-keys-6.0.0.tgz#12a07a6f50189213c3e8626c4069e28b997d01d1"
+  integrity sha512-NW1C7M9/uDZlfDP0+pWv0yAtgni7AZ9bYKtWgIfJylNXUFfis2BxsX3lCVuZE12wtRePEfJjnG6T9CnMohEybw==
+  dependencies:
+    camelcase "^5.3.1"
+    map-obj "^4.0.0"
+    quick-lru "^4.0.1"
+
 camelcase@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-3.0.0.tgz#32fc4b9fcdaf845fcdf7e73bb97cac2261f0ab0a"
   integrity sha1-MvxLn82vhF/N9+c7uXysImHwqwo=
+
+camelcase@^5.3.1:
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
+  integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -1105,7 +1119,7 @@ har-schema@^2.0.0:
 har-validator@~5.1.0:
   version "5.1.3"
   resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-5.1.3.tgz#1ef89ebd3e4996557675eed9893110dc350fa080"
-  integrity "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g=="
+  integrity sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==
   dependencies:
     ajv "^6.5.5"
     har-schema "^2.0.0"
@@ -1844,6 +1858,11 @@ makeerror@1.0.x:
   dependencies:
     tmpl "1.0.x"
 
+map-obj@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-4.1.0.tgz#b91221b542734b9f14256c0132c897c5d7256fd5"
+  integrity sha512-glc9y00wgtwcDmp7GaE/0b0OnxpNJsVf3ael/An6Fe2Q51LLwN1er6sdomLRzz5h0+yMpiYLhWYF5R7HeqVd4g==
+
 math-random@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/math-random/-/math-random-1.0.1.tgz#8b3aac588b8a66e4975e3cdea67f7bb329601fac"
@@ -2226,6 +2245,11 @@ qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
+
+quick-lru@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-4.0.1.tgz#5b8878f113a58217848c6482026c73e1ba57727f"
+  integrity sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==
 
 randomatic@^3.0.0:
   version "3.1.1"


### PR DESCRIPTION
This adds the following:

```js
var libRegions = require('@luxuryescapes/lib-regions')
libRegions.setCamel()
```

This will return everything as camel case so that you can migrate off the snake case. After people have changed we can remove this and change all the keys to camel in the data itself.